### PR TITLE
fix an error in distance formula

### DIFF
--- a/dynamic_listings/C++/default/collisiondetection/circle_circle.txt
+++ b/dynamic_listings/C++/default/collisiondetection/circle_circle.txt
@@ -8,7 +8,7 @@ struct Circle{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool circle_circle_collision(Circle A, Circle B){

--- a/dynamic_listings/C++/default/collisiondetection/circle_circle_lazy.txt
+++ b/dynamic_listings/C++/default/collisiondetection/circle_circle_lazy.txt
@@ -8,7 +8,7 @@ struct Circle{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool circle_circle_collision(Circle A, Circle B){

--- a/dynamic_listings/C++/default/collisiondetection/line_circle.txt
+++ b/dynamic_listings/C++/default/collisiondetection/line_circle.txt
@@ -17,7 +17,7 @@ struct Circle{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool line_point_collision(Line l, Point p){

--- a/dynamic_listings/C++/default/collisiondetection/line_point.txt
+++ b/dynamic_listings/C++/default/collisiondetection/line_point.txt
@@ -11,7 +11,7 @@ struct Line{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool line_point_collision(Point pt, Line ln){

--- a/dynamic_listings/C++/default/collisiondetection/point_circle.txt
+++ b/dynamic_listings/C++/default/collisiondetection/point_circle.txt
@@ -8,7 +8,7 @@ struct Circle{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool circle_point_collision(Circle A, Point B){

--- a/dynamic_listings/C++/default/collisiondetection/point_circle_lazy.txt
+++ b/dynamic_listings/C++/default/collisiondetection/point_circle_lazy.txt
@@ -7,7 +7,7 @@ struct Circle{
 
 float distance(Point A, Point B){
     // Calculates the distance between two points
-    return std::sqrt(std::pow((A.x + B.x),2) + std::pow((A.y + B.y),2));
+    return std::sqrt(std::pow((A.x - B.x),2) + std::pow((A.y - B.y),2));
 }
 
 bool circle_point_collision(Circle A, Point B){

--- a/dynamic_listings/javascript/default/collisiondetection/circle_circle.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/circle_circle.txt
@@ -8,7 +8,7 @@ class Circle{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_circle_collision(A, B){

--- a/dynamic_listings/javascript/default/collisiondetection/circle_circle_lazy.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/circle_circle_lazy.txt
@@ -8,7 +8,7 @@ class Circle{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_circle_collision(A, B){

--- a/dynamic_listings/javascript/default/collisiondetection/line_circle.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/line_circle.txt
@@ -28,7 +28,7 @@ class Circle{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function line_point_collision(line, point){

--- a/dynamic_listings/javascript/default/collisiondetection/line_point.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/line_point.txt
@@ -15,7 +15,7 @@ class Line{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function line_point_collision(pt, ln){

--- a/dynamic_listings/javascript/default/collisiondetection/point_circle.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/point_circle.txt
@@ -8,7 +8,7 @@ class Circle{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_point_collision(A, B){

--- a/dynamic_listings/javascript/default/collisiondetection/point_circle_lazy.txt
+++ b/dynamic_listings/javascript/default/collisiondetection/point_circle_lazy.txt
@@ -8,7 +8,7 @@ class Circle{
 
 function distance(A, B){
     // Calculates the distance between two points
-    return Math.sqrt((A.x + B.x)^2 + (A.y + B.y)^2);
+    return Math.sqrt((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_point_collision(A, B){

--- a/dynamic_listings/pseudocode/default/collisiondetection/circle_circle.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/circle_circle.txt
@@ -6,7 +6,7 @@ structure Circle{
 
 function distance(Point A, Point B) -> float{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_circle_collision(Circle A, Circle B) -> bool{

--- a/dynamic_listings/pseudocode/default/collisiondetection/circle_circle_lazy.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/circle_circle_lazy.txt
@@ -6,7 +6,7 @@ structure Circle{
 
 function distance(Point A, Point B) -> float{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_circle_collision(Circle A, Circle B) -> bool{

--- a/dynamic_listings/pseudocode/default/collisiondetection/line_circle.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/line_circle.txt
@@ -15,7 +15,7 @@ structure Circle{
 
 function distance(Point A, Point B) -> float{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function line_point_collision(Line line, Point point) -> bool{

--- a/dynamic_listings/pseudocode/default/collisiondetection/line_point.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/line_point.txt
@@ -10,7 +10,7 @@ structure Line{
 
 function distance(Point A, Point B) -> float{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function line_point_collision(Point pt, Line ln) -> bool{

--- a/dynamic_listings/pseudocode/default/collisiondetection/point_circle.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/point_circle.txt
@@ -6,7 +6,7 @@ structure Circle{
 
 function distance(Point A, Point B) -> float{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_point_collision(Circle A, Point B) -> bool{

--- a/dynamic_listings/pseudocode/default/collisiondetection/point_circle_lazy.txt
+++ b/dynamic_listings/pseudocode/default/collisiondetection/point_circle_lazy.txt
@@ -6,7 +6,7 @@ structure Circle{
 
 function distance(Point A, Point B) -> bool{
     // Calculates the distance between two points
-    return square_root((A.x + B.x)^2 + (A.y + B.y)^2);
+    return square_root((A.x - B.x)^2 + (A.y - B.y)^2);
 }
 
 function circle_point_collision(Circle A, Point B) -> bool{

--- a/dynamic_listings/python/default/collisiondetection/circle_circle.txt
+++ b/dynamic_listings/python/default/collisiondetection/circle_circle.txt
@@ -26,7 +26,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def circle_circle_collision(A, B):

--- a/dynamic_listings/python/default/collisiondetection/circle_circle_lazy.txt
+++ b/dynamic_listings/python/default/collisiondetection/circle_circle_lazy.txt
@@ -26,7 +26,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def circle_circle_collision(A, B):

--- a/dynamic_listings/python/default/collisiondetection/line_circle.txt
+++ b/dynamic_listings/python/default/collisiondetection/line_circle.txt
@@ -72,7 +72,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def line_circle_collision(circle, line):

--- a/dynamic_listings/python/default/collisiondetection/line_point.txt
+++ b/dynamic_listings/python/default/collisiondetection/line_point.txt
@@ -40,7 +40,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def line_point_collision(pt, ln):

--- a/dynamic_listings/python/default/collisiondetection/point_circle.txt
+++ b/dynamic_listings/python/default/collisiondetection/point_circle.txt
@@ -26,7 +26,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def circle_point_collision(A, B):

--- a/dynamic_listings/python/default/collisiondetection/point_circle_lazy.txt
+++ b/dynamic_listings/python/default/collisiondetection/point_circle_lazy.txt
@@ -26,7 +26,7 @@ def distance(A, B):
     :returns: A float that represents the distance between A and B
 
     """
-    return sqrt((A.x + B.x)**2 + (A.y + B.y)**2)
+    return sqrt((A.x - B.x)**2 + (A.y - B.y)**2)
 
 
 def circle_point_collision(A, B):


### PR DESCRIPTION
Hello. looks like i did find a mistake in distance formula.
And please sorry for my english =)

## Description

according to https://www.cuemath.com/geometry/distance-between-two-points/ 
square_root((A.x + B.x)^2 + (A.y + B.y)^2) is wrong, and should be 
square_root((A.x - B.x)^2 + (A.y - B.y)^2)

## Context and motivation

I am just studying, and happend to bump on this. Trying make things better

## Type of changes:

<!-- Please check what applies by putting an `x` in the boxes that apply -->

- [ ] Added new chapters
- [x] Fixed mistakes
- [ ] Filled placeholders

## Checklist

<!-- Go over the following points, check all that apply, if unsure, don't hesitate to ask -->

- [x] My contribution follows the contribution guidelines
- [ ] I added myself in the contributors section (or I am already present)
- [ ] I consent that my contribution will be distributed under the CC BY-NC License
